### PR TITLE
Feature: export to mdf

### DIFF
--- a/pypif_sdk/interop/mdf.py
+++ b/pypif_sdk/interop/mdf.py
@@ -1,0 +1,61 @@
+from pypif_sdk.readview import ReadView
+from pypif.obj.common import Value
+from json import dumps
+
+
+def pif_to_mdf_record(pif):
+   """Convert a PIF into partial MDF record"""
+   res = {}
+   res["mdf"] = _to_meta_data(pif)
+   res["{source_name}"] = _to_user_defined(pif)
+   return dumps(res)
+
+
+def _to_meta_data(pif):
+    """Convert the meta-data from the PIF into MDF"""
+    return {}
+
+
+def _to_user_defined(pif):
+    """Read the systems in the PIF to populate the user-defined portion"""
+    res = {}
+
+    # make a read view to flatten the heirarchy
+    rv = ReadView(pif)
+
+    # Iterate over the keys in the read view
+    for k in rv.keys():
+        name, value = _extract_key_value(rv[k].raw)
+        # add any objects that can be extracted
+        if name and value is not None:
+            res[name] = value
+    return res
+
+
+def _construct_new_key(name, units=None):
+    """Construct an MDF safe key from the name and units"""
+    cat = name
+    if units:
+        cat = "_".join([name, units])
+    to_remove = ["/", "\\", "*", "^", "#", " ", "\n", "\t"]
+    for c in to_remove:
+       cat = cat.replace(c, "_")
+    return cat
+
+
+def _extract_key_value(obj):
+    """Extract the value from the object and make a descriptive key"""
+
+    # Parse a Value object, which includes Properties
+    if isinstance(obj, Value):
+        key = _construct_new_key(obj.name, obj.units)
+        value = None
+        if obj.scalars and len(obj.scalars) == 1:
+            value = obj.scalars[0].value
+        elif obj.scalars:
+            value =  [x.value for x in obj.scalars]
+        elif obj.vectors and len(obj.vectors) == 1:
+            value = [x.value for x in obj.vectors[0]]
+        
+    return key, value
+

--- a/pypif_sdk/interop/tests/test_mdf_interop.py
+++ b/pypif_sdk/interop/tests/test_mdf_interop.py
@@ -1,0 +1,56 @@
+from pypif.obj.common import Property, Scalar, Person, Name, License, Reference, Value
+from pypif.obj.system import System, ChemicalSystem
+from pypif_sdk.interop.mdf import _to_user_defined, _construct_new_key
+
+
+test_pif = ChemicalSystem(
+    chemical_formula="CH4",
+    names = ["methane", "fart"],
+    contacts = [Person(name=Name(given="Albert", family="Einstein")), Person(email="admin@citrine.io")],
+    references = [Reference(doi="doi", authors=[Name(given="Captain", family="Marvel")])],
+    licenses = [License(url="url")],
+    tags = ["too long", "didn't read"],
+    properties = [
+        Property(name="foo", scalars=[Scalar(value="bar")]),
+        Property(name="spam", scalrs=[Scalar(value="eggs")])
+    ]
+)
+
+
+def test_property_value():
+    """Test that a simple property gets pulled out"""
+    sys = System(properties=[Property(name="foo", scalars=[Scalar(value="bar")])])
+    user_data = _to_user_defined(sys)
+    assert user_data["foo"] == "bar"
+   
+ 
+def test_property_list():
+    """Test that a property with a list of scalars gets pulled out"""
+    sys = System(properties=[Property(name="foo", scalars=[Scalar(value="spam"), Scalar(value="eggs")])])
+    user_data = _to_user_defined(sys)
+    assert user_data["foo"] == ["spam", "eggs"] 
+
+
+def test_property_vector():
+    """Test that a vector gets pulled out"""
+    sys = System(properties=[Property(name="foo", units="bar", vectors=[[Scalar(value="spam"), Scalar(value="eggs")]])])
+    user_data = _to_user_defined(sys)
+    assert user_data["foo_bar"] == ["spam", "eggs"] 
+
+
+def test_condition():
+    """Test that conditions are flattened and added"""
+    condition = Value(name="spam", scalars=[Scalar(value="eggs")])
+    sys = System(properties=[
+        Property(name="foo", scalars=[Scalar(value="bar")], conditions=[condition])
+    ])
+    user_data = _to_user_defined(sys)
+    assert user_data["spam"] == "eggs"
+
+
+def test_construct_new_key():
+    """Test the new key constructions"""
+    assert _construct_new_key("foo") == "foo"
+    assert _construct_new_key("foo", units="bar") == "foo_bar"
+    assert _construct_new_key("foo bar") == "foo_bar"
+    assert _construct_new_key("#foo", units="g/cm^3") == "_foo_g_cm_3"


### PR DESCRIPTION
This adds an interoperability package with "export to MDF" capability.

Relocated from [here](https://github.com/CitrineInformatics/pypif/pull/52).