### PR TITLE
Datacite missing metadata handling

### DIFF
--- a/pypif_sdk/interop/datacite.py
+++ b/pypif_sdk/interop/datacite.py
@@ -46,13 +46,13 @@ def datacite_to_pif_reference(dc):
     :return: Reference corresponding to that datacite entry
     """
     ref = Reference()
-    if dc.get('identifier').get('identifierType') == "DOI":
-        ref.doi = dc.get('identifier').get('identifier')
+    if dc.get('identifier', {}).get('identifierType') == "DOI":
+        ref.doi = dc.get('identifier', {}).get('identifier')
     ref.title = dc.get('title')
     ref.publisher = dc.get('publisher')
     ref.year = dc.get('publicationYear')
 
-    ref.authors = [creator_to_person(x).name for x in dc.get('creators')]
+    ref.authors = [creator_to_person(x).name for x in dc.get('creators', [])]
 
     return ref
 

--- a/pypif_sdk/interop/datacite.py
+++ b/pypif_sdk/interop/datacite.py
@@ -52,7 +52,7 @@ def datacite_to_pif_reference(dc):
     ref.publisher = dc.get('publisher')
     ref.year = dc.get('publicationYear')
 
-    ref.authors = [creator_to_person(x).name for x in dc.get('creators', [])]
+    ref.authors = [creator_to_person(x).name for x in dc.get('creators', [])] or None
 
     return ref
 

--- a/pypif_sdk/interop/tests/test_datacite.py
+++ b/pypif_sdk/interop/tests/test_datacite.py
@@ -85,4 +85,15 @@ def test_add_datacite():
     }
     res = add_datacite(data_pif, dc)
     assert res.properties[0].scalars[0].value == "bar"
-    assert res.references[0].doi == "000.000" 
+    assert res.references[0].doi == "000.000"
+
+    data_pif2 = System(properties=[Property(name="Foo", scalars=[Scalar(value="bar")])])
+    dc2 = {
+        "title": "The joy of the PIF",
+        "publisher": "Ether",
+        "publicationYear": "2014",
+        "creators": [{"creatorName": "Kyle Michel", "affiliations": ["Berklee", "NW"]}]
+    }
+    res2 = add_datacite(data_pif2, dc2)
+    assert res2.properties[0].scalars[0].value == "bar"
+    assert res2.references[0].doi is None


### PR DESCRIPTION
`pypif_sdk.interop.datacite.datacite_to_pif_reference()` raises an exception if either `identifier` or `creators` is not present in the DataCite metadata. Since `None` is a valid value for `Reference` properties, it makes more sense to use that as a default value instead of raising an exception, as is done with `title`, `publisher`, and `year`.
Also adding a test for this case.