### PR TITLE
Make support for pycc version 4x explicit

### DIFF
--- a/pypif_sdk/interop/mdf.py
+++ b/pypif_sdk/interop/mdf.py
@@ -24,7 +24,8 @@ def query_to_mdf_records(query=None, dataset_id=None, mdf_acl=None):
                 dataset=DatasetQuery(
                     id=Filter(equal=dataset_id)
                 )
-            )
+            ),
+            size = 10000 # Don't pull down all the results by default
         )
 
     client = get_client()
@@ -42,7 +43,8 @@ def query_to_mdf_records(query=None, dataset_id=None, mdf_acl=None):
             system=PifSystemQuery(
                 uid=Filter(equal=example_uid)
             )
-        )
+        ),
+        size = 1 # we only expect one dataset to hit
     )
 
     dataset_result = client.dataset_search(dataset_query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pypif==2.0.0
-citrination_client==4.0.1
+citrination_client==4.1.0
 toolz==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pypif==2.0.0
-citrination_client==3.0.0
+citrination_client==4.0.1
 toolz==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='pypif-sdk',
       packages=find_packages(),
       install_requires=[
           'pypif>=2.0.0,<4',
-          'citrination_client>=3,<4',
+          'citrination_client>=3,<5',
           'toolz'
       ])


### PR DESCRIPTION
The pycc 3x to 4x update is mostly backward compatible, so there
are no substantative changes included here.  To avoid new warnings,
the sizes of the queries generated in `query_to_mdf_records` is
now made explicit.  The version in requirements.txt is bumped so
we test against 4x.