### PR TITLE
Feature/update pycc dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,13 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'
 install:
 - pip install pytest
 - pip install -U -r requirements.txt
-- pip install --no-deps -e . 
+- pip install --no-deps -e .
 script:
 - py.test -s --verbose
 deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pypif==2.0.0
-citrination_client==5.3.0
+citrination_client==6.3.0
 toolz==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pypif==2.0.0
-citrination_client==6.3.0
+citrination_client==5.4.0
 toolz==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pypif==2.0.0
-citrination_client==5.4.0
+citrination_client==5.3.0
 toolz==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pypif==2.0.0
-citrination_client==4.1.0
+citrination_client==6.3.0
 toolz==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(name='pypif-sdk',
       package_data={'pypif_sdk' : ['func/elements.json']},
       install_requires=[
           'pypif>=2.0.0,<4',
-          'citrination_client>=3,<5',
+          'citrination_client>=3',
           'toolz',
       ])

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(name='pypif-sdk',
       package_data={'pypif_sdk' : ['func/elements.json']},
       install_requires=[
           'pypif>=2.0.0,<4',
-          'citrination_client>=3',
+          'citrination_client>=3,<7',
           'toolz',
       ])


### PR DESCRIPTION
Remove python 3.3 from travis.yml, no longer supported

Remove <5 version dependency for citrination_client

      The search related logic for pycc has not been touched in a long
      while, whereas newer features like API ingest have been added. This
      change will for compatibility will pycc 5.x and 6.x.

Also drop python 3.4 support, incompatible with PyYAML